### PR TITLE
SSE fix for Discord clients and possibly others. Seems to work with ST?

### DIFF
--- a/claude_bridge.py
+++ b/claude_bridge.py
@@ -3874,7 +3874,22 @@ Now, based on this context, please respond to the following request:
         worker_thread.start()
 
         def response_generator(as_sse: bool):
-            keepalive = ": keepalive\n\n" if as_sse else " "
+            if as_sse:
+                # Send a real empty-delta SSE data event instead of a comment.
+                # SSE comments (": keepalive") are skipped by OpenAI-compatible
+                # clients like TomoriBot, so their inactivity timers never reset
+                # while Claude is thinking.  A proper but empty chunk keeps those
+                # timers alive and is a no-op for all compliant streaming clients.
+                _kl_payload = json.dumps({
+                    "id": "keepalive",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": DEFAULT_MODEL,
+                    "choices": [{"index": 0, "delta": {"content": ""}, "finish_reason": None}],
+                })
+                keepalive = f"data: {_kl_payload}\n\n"
+            else:
+                keepalive = " "
             try:
                 while worker_thread.is_alive():
                     worker_thread.join(timeout=1.0)


### PR DESCRIPTION
Very minor fix by clod with me looking over its shoulder. I saw you'd been doing some bughunting here as well. 

This, so far, seems to make it work reliably as a pure OpenAI-compatible proxy - my use case is a locally hosted Discord bot. I tested it with ST on 4.7, 4.6, and Sonnet, including with think tags, and everything seemed to work fine. But I'm not really an ST power user, didn't do any tool calling, etc.  

Anyway, if you look at it and go "oh THAT'S it", feel free to merge, but if you know it'll break something for ST use cases feel free to ignore it. Thanks for the tool and have an awesome day!

-baetican